### PR TITLE
Setting CXX standard in test package to make it work in other CI environments

### DIFF
--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -3,8 +3,9 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+set(CMAKE_CXX_STANDARD 14)
+
 message("LIBS: ${CONAN_LIBS}")
 
-set (CMAKE_CXX_STANDARD 11)
 add_executable(test_package test_package.cpp)
 target_link_libraries(test_package ${CONAN_LIBS})

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -5,5 +5,6 @@ conan_basic_setup()
 
 message("LIBS: ${CONAN_LIBS}")
 
+set (CMAKE_CXX_STANDARD 11)
 add_executable(test_package test_package.cpp)
 target_link_libraries(test_package ${CONAN_LIBS})


### PR DESCRIPTION
Test package wasn't working on mac or in linux/gcc5.

Discovered while reviewing it for inclusion request. https://github.com/conan-community/community/issues/7